### PR TITLE
espresso: fix invalid kpoints config generation

### DIFF
--- a/espresso/espresso.py
+++ b/espresso/espresso.py
@@ -1264,7 +1264,7 @@ svn co --username anonymous http://qeforge.qe-forge.org/svn/q-e/branches/espress
             x = np.shape(kp)
             if len(x)==1:
                 print('K_POINTS automatic', file=finp)
-                print(kp[0], kp[1], kp[2], file=finp)
+                print(kp[0], kp[1], kp[2], file=finp, end=' ')
                 if overridekptshift is None:
                     print(self.kptshift[0],self.kptshift[1],self.kptshift[2], file=finp)
                 else:


### PR DESCRIPTION
Possible source for this error is the automatic conversion which
neglects a trailing ',' used in Python 2 to avoid a line break.
